### PR TITLE
Expand header tests to increase coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5768,13 +5768,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5787,18 +5785,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5901,8 +5896,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5912,7 +5906,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5925,20 +5918,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5955,7 +5945,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6028,8 +6017,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6039,7 +6027,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6145,7 +6132,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9029,6 +9015,11 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "mockdate": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-2.0.2.tgz",
+      "integrity": "sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI="
     },
     "moo": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jest-pnp-resolver": "1.0.1",
     "jest-resolve": "23.6.0",
     "mini-css-extract-plugin": "0.4.3",
+    "mockdate": "^2.0.2",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.1.0",
     "postcss-flexbugs-fixes": "4.1.0",

--- a/src/__tests__/Header-test.tsx
+++ b/src/__tests__/Header-test.tsx
@@ -2,27 +2,12 @@ import React from 'react';
 import { shallow, mount, render } from 'enzyme';
 import Header from '../components/Header';
 
-function mockCurrentDate(dateToUse: string): void {
-    let DATE_TO_USE = new Date(dateToUse);
-    let _Date = Date;
-    // @ts-ignore -- Next line gives an error but it doesn't have to actually work correctly!
-    global.Date = jest.fn(() => DATE_TO_USE); 
-    global.Date.UTC = _Date.UTC;
-    global.Date.parse = _Date.parse;
-    global.Date.now = _Date.now;
-}
-
-// jest.spyOn(Date, 'now').mockImplementation(() => 1479427200000)
+var MockDate = require('mockdate'); // U.S. Style date!!!
 
 describe('Header', () => {
 
-    let headerComponent = shallow(<Header />);
-
-    beforeEach(() => {
-    })
-
     afterEach(() => {
-     //   headerComponent.unmount();
+     MockDate.reset();
       });
 
     it('contains a header tag', () => {
@@ -38,72 +23,76 @@ describe('Header', () => {
     })
 
     it('displays correct date for January & Monday', () => {
-        mockCurrentDate('2018-01-01T04:41:20');
-        headerComponent.setState({ day: 1, month: "January", year: 2018, weekDay: "Monday" });
-        expect(headerComponent.find('p').html()).toContain('Monday, 1 January, 2018');
+        MockDate.set('1/1/2018');
+        shallow(<Header />).setState({ day: 1, month: "January", year: 2018, weekDay: "Monday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Monday, 1 January, 2018');
+        // the reason why I'm setting a new shallow(<Header />) at every test is ti instantiate it every time seperately.
     })
 
     it('displays correct date for February & Wednesday', () => {
-        mockCurrentDate('2018-02-07T04:45:20');
-        headerComponent.setState({ day: 7, month: "February", year: 2018, weekDay: "Wednesday" });
-        expect(headerComponent.find('p').html()).toContain('Wednesday, 7 February, 2018');
+        MockDate.set('2/7/2018');
+        shallow(<Header />).setState({ day: 7, month: "February", year: 2018, weekDay: "Wednesday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Wednesday, 7 February, 2018');
     })
 
     it('displays correct date for March & Thursday', () => {
-        mockCurrentDate('2018-03-01T01:41:20');
-        headerComponent.setState({ day: 1, month: "March", year: 2018, weekDay: "Thursday" });
-        expect(headerComponent.find('p').html()).toContain('Thursday, 1 March, 2018');
+        MockDate.set('3/1/2018');
+        shallow(<Header />).setState({ day: 1, month: "March", year: 2018, weekDay: "Thursday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Thursday, 1 March, 2018');
     })
 
     it('displays correct date for April & Friday', () => {
-        mockCurrentDate('2018-04-06T01:41:20');
-        headerComponent.setState({ day: 6, month: "April", year: 2018, weekDay: "Friday" });
-        expect(headerComponent.find('p').html()).toContain('Friday, 6 April, 2018');
+        MockDate.set('4/6/2018');
+        shallow(<Header />).setState({ day: 6, month: "April", year: 2018, weekDay: "Friday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Friday, 6 April, 2018');
     })
 
     it('displays correct date for May & Saturday', () => {
-        mockCurrentDate('2018-05-05T01:41:20');
-        headerComponent.setState({ day: 5, month: "May", year: 2018, weekDay: "Saturday" });
-        expect(headerComponent.find('p').html()).toContain('Saturday, 5 May, 2018');
+        MockDate.set('5/5/2018');
+        shallow(<Header />).setState({ day: 5, month: "May", year: 2018, weekDay: "Saturday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Saturday, 5 May, 2018');
     })
 
     it('displays correct date for June & Sunday', () => {
-        mockCurrentDate('2018-06-03T01:41:20');
-        headerComponent.setState({ day: 3, month: "June", year: 2018, weekDay: "Sunday" });
-        expect(headerComponent.find('p').html()).toContain('Sunday, 3 June, 2018');
+        MockDate.set('6/3/2018');
+        shallow(<Header />).setState({ day: 3, month: "June", year: 2018, weekDay: "Sunday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Sunday, 3 June, 2018');
     })
 
     it('displays correct date for July', () => {
-        mockCurrentDate('2018-07-01T01:41:20');
-        headerComponent.setState({ day: 1, month: "July", year: 2018, weekDay: "Sunday" });
-        expect(headerComponent.find('p').html()).toContain('Sunday, 1 July, 2018');
+        MockDate.set('7/1/2018');
+        shallow(<Header />).setState({ day: 1, month: "July", year: 2018, weekDay: "Sunday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Sunday, 1 July, 2018');
     })
 
     it('displays correct date for August', () => {
-        mockCurrentDate('2018-08-05T01:41:20');
-        headerComponent.setState({ day: 5, month: "August", year: 2018, weekDay: "Sunday" });
-        expect(headerComponent.find('p').html()).toContain('Sunday, 5 August, 2018');
+        MockDate.set('8/5/2018');
+        shallow(<Header />).setState({ day: 5, month: "August", year: 2018, weekDay: "Sunday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Sunday, 5 August, 2018');
     })
 
     it('displays correct date for September', () => {
-        mockCurrentDate('2018-09-02T01:41:20');
-        headerComponent.setState({ day: 2, month: "September", year: 2018, weekDay: "Sunday" });
-        expect(headerComponent.find('p').html()).toContain('Sunday, 2 September, 2018');
+        MockDate.set('9/2/2018');
+        shallow(<Header />).setState({ day: 2, month: "September", year: 2018, weekDay: "Sunday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Sunday, 2 September, 2018');
     })
 
     it('displays correct date for October', () => {
-        headerComponent.setState({ day: 7, month: "October", year: 2018, weekDay: "Sunday" });
-        expect(headerComponent.find('p').html()).toContain('Sunday, 7 October, 2018');
+        MockDate.set('10/7/2018');
+        shallow(<Header />).setState({ day: 7, month: "October", year: 2018, weekDay: "Sunday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Sunday, 7 October, 2018');
     })
 
     it('displays correct date for November', () => {
-        headerComponent.setState({ day: 4, month: "November", year: 2018, weekDay: "Sunday" });
-        expect(headerComponent.find('p').html()).toContain('Sunday, 4 November, 2018');
+        MockDate.set('11/4/2018');
+        shallow(<Header />).setState({ day: 4, month: "November", year: 2018, weekDay: "Sunday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Sunday, 4 November, 2018');
     })
 
     it('displays correct date for December & Tuesday', () => {
-        headerComponent.setState({ day: 11, month: "December", year: 2018, weekDay: "Tuesday" });
-        expect(headerComponent.find('p').html()).toContain('Tuesday, 11 December, 2018');
+        MockDate.set('12/11/2018');
+        shallow(<Header />).setState({ day: 11, month: "December", year: 2018, weekDay: "Tuesday" });
+        expect(shallow(<Header />).find('p').html()).toContain('Tuesday, 11 December, 2018');
     })
 
     it('calls componentDidMount on load', () => {

--- a/src/__tests__/Header-test.tsx
+++ b/src/__tests__/Header-test.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { shallow, mount, render } from 'enzyme';
 import Header from '../components/Header';
 
-
 function mockCurrentDate(dateToUse: string): void {
-    const DATE_TO_USE = new Date(dateToUse);
-    const _Date = Date;
+    let DATE_TO_USE = new Date(dateToUse);
+    let _Date = Date;
     // @ts-ignore -- Next line gives an error but it doesn't have to actually work correctly!
     global.Date = jest.fn(() => DATE_TO_USE); 
     global.Date.UTC = _Date.UTC;
@@ -13,12 +12,18 @@ function mockCurrentDate(dateToUse: string): void {
     global.Date.now = _Date.now;
 }
 
+// jest.spyOn(Date, 'now').mockImplementation(() => 1479427200000)
+
 describe('Header', () => {
 
-    const headerComponent = shallow(<Header />);
+    let headerComponent = shallow(<Header />);
 
     beforeEach(() => {
-    });
+    })
+
+    afterEach(() => {
+     //   headerComponent.unmount();
+      });
 
     it('contains a header tag', () => {
         expect(shallow(<Header />).find('header')).toBeTruthy();
@@ -105,6 +110,12 @@ describe('Header', () => {
         jest.spyOn(Header.prototype, 'componentDidMount');
         shallow(<Header />);
         expect(Header.prototype.componentDidMount).toHaveBeenCalled();
+    });
+
+    it('calls setDate function', () => {
+        jest.spyOn(Header.prototype, 'setDate');
+        shallow(<Header />);
+        expect(Header.prototype.setDate).toHaveBeenCalled();
     });
 
 });

--- a/src/__tests__/Header-test.tsx
+++ b/src/__tests__/Header-test.tsx
@@ -3,11 +3,12 @@ import { shallow, mount, render } from 'enzyme';
 import Header from '../components/Header';
 
 describe('Header', () => {
-    
+
     const constantDate = new Date('2017-06-13T04:41:20');
+    const headerComponent = shallow(<Header />);
 
     beforeEach(() => {
-       const test = jest.mock('../components/Header'); // Header is now a mock constructor
+        const test = jest.mock('../components/Header'); // Header is now a mock constructor
     });
 
     it('contains a header tag', () => {
@@ -23,81 +24,70 @@ describe('Header', () => {
     })
 
     it('displays correct date for January & Monday', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 1, month: "January", year: 2018, weekDay: "Monday"} );
-       expect(headerComponent.find('p').html()).toContain('Monday, 1 January, 2018');
+
+        headerComponent.setState({ day: 1, month: "January", year: 2018, weekDay: "Monday" });
+        expect(headerComponent.find('p').html()).toContain('Monday, 1 January, 2018');
     })
 
     it('displays correct date for February & Wednesday', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 7, month: "February", year: 2018, weekDay: "Wednesday"} );
-       expect(headerComponent.find('p').html()).toContain('Wednesday, 7 February, 2018');
+        headerComponent.setState({ day: 7, month: "February", year: 2018, weekDay: "Wednesday" });
+        expect(headerComponent.find('p').html()).toContain('Wednesday, 7 February, 2018');
     })
 
     it('displays correct date for March & Thursday', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 1, month: "March", year: 2018, weekDay: "Thursday"} );
-       expect(headerComponent.find('p').html()).toContain('Thursday, 1 March, 2018');
+        headerComponent.setState({ day: 1, month: "March", year: 2018, weekDay: "Thursday" });
+        expect(headerComponent.find('p').html()).toContain('Thursday, 1 March, 2018');
     })
 
     it('displays correct date for April & Friday', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 6, month: "April", year: 2018, weekDay: "Friday"} );
-       expect(headerComponent.find('p').html()).toContain('Friday, 6 April, 2018');
+        headerComponent.setState({ day: 6, month: "April", year: 2018, weekDay: "Friday" });
+        expect(headerComponent.find('p').html()).toContain('Friday, 6 April, 2018');
     })
 
     it('displays correct date for May & Saturday', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 5, month: "May", year: 2018, weekDay: "Saturday"} );
-       expect(headerComponent.find('p').html()).toContain('Saturday, 5 May, 2018');
+        headerComponent.setState({ day: 5, month: "May", year: 2018, weekDay: "Saturday" });
+        expect(headerComponent.find('p').html()).toContain('Saturday, 5 May, 2018');
     })
 
     it('displays correct date for June & Sunday', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 3, month: "June", year: 2018, weekDay: "Sunday"} );
-       expect(headerComponent.find('p').html()).toContain('Sunday, 3 June, 2018');
+        headerComponent.setState({ day: 3, month: "June", year: 2018, weekDay: "Sunday" });
+        expect(headerComponent.find('p').html()).toContain('Sunday, 3 June, 2018');
     })
 
     it('displays correct date for July', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 1, month: "July", year: 2018, weekDay: "Sunday"} );
-       expect(headerComponent.find('p').html()).toContain('Sunday, 1 July, 2018');
+        headerComponent.setState({ day: 1, month: "July", year: 2018, weekDay: "Sunday" });
+        expect(headerComponent.find('p').html()).toContain('Sunday, 1 July, 2018');
     })
 
     it('displays correct date for August', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 5, month: "August", year: 2018, weekDay: "Sunday"} );
-       expect(headerComponent.find('p').html()).toContain('Sunday, 5 August, 2018');
+        headerComponent.setState({ day: 5, month: "August", year: 2018, weekDay: "Sunday" });
+        expect(headerComponent.find('p').html()).toContain('Sunday, 5 August, 2018');
     })
 
     it('displays correct date for September', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 2, month: "September", year: 2018, weekDay: "Sunday"} );
-       expect(headerComponent.find('p').html()).toContain('Sunday, 2 September, 2018');
+        headerComponent.setState({ day: 2, month: "September", year: 2018, weekDay: "Sunday" });
+        expect(headerComponent.find('p').html()).toContain('Sunday, 2 September, 2018');
     })
 
     it('displays correct date for October', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 7, month: "October", year: 2018, weekDay: "Sunday"} );
-       expect(headerComponent.find('p').html()).toContain('Sunday, 7 October, 2018');
+        headerComponent.setState({ day: 7, month: "October", year: 2018, weekDay: "Sunday" });
+        expect(headerComponent.find('p').html()).toContain('Sunday, 7 October, 2018');
     })
 
     it('displays correct date for November', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 4, month: "November", year: 2018, weekDay: "Sunday"} );
-       expect(headerComponent.find('p').html()).toContain('Sunday, 4 November, 2018');
+        headerComponent.setState({ day: 4, month: "November", year: 2018, weekDay: "Sunday" });
+        expect(headerComponent.find('p').html()).toContain('Sunday, 4 November, 2018');
     })
 
     it('displays correct date for December & Tuesday', () => {
-        const headerComponent = shallow(<Header />);
-        headerComponent.setState( { day: 11, month: "December", year: 2018, weekDay: "Tuesday"} );
-       expect(headerComponent.find('p').html()).toContain('Tuesday, 11 December, 2018');
-    }) // // Do this for all other posibilities to increase the coverage.
+        headerComponent.setState({ day: 11, month: "December", year: 2018, weekDay: "Tuesday" });
+        expect(headerComponent.find('p').html()).toContain('Tuesday, 11 December, 2018');
+    })
 
     it('calls componentDidMount on load', () => {
-            jest.spyOn(Header.prototype, 'componentDidMount');
-            shallow(<Header />);
-            expect(Header.prototype.componentDidMount).toHaveBeenCalled();
+        jest.spyOn(Header.prototype, 'componentDidMount');
+        shallow(<Header />);
+        expect(Header.prototype.componentDidMount).toHaveBeenCalled();
     });
 
 });

--- a/src/__tests__/Header-test.tsx
+++ b/src/__tests__/Header-test.tsx
@@ -2,13 +2,22 @@ import React from 'react';
 import { shallow, mount, render } from 'enzyme';
 import Header from '../components/Header';
 
+
+function mockCurrentDate(dateToUse: string): void {
+    const DATE_TO_USE = new Date(dateToUse);
+    const _Date = Date;
+    // @ts-ignore -- Next line gives an error but it doesn't have to actually work correctly!
+    global.Date = jest.fn(() => DATE_TO_USE); 
+    global.Date.UTC = _Date.UTC;
+    global.Date.parse = _Date.parse;
+    global.Date.now = _Date.now;
+}
+
 describe('Header', () => {
 
-    const constantDate = new Date('2017-06-13T04:41:20');
     const headerComponent = shallow(<Header />);
 
     beforeEach(() => {
-        const test = jest.mock('../components/Header'); // Header is now a mock constructor
     });
 
     it('contains a header tag', () => {
@@ -24,47 +33,55 @@ describe('Header', () => {
     })
 
     it('displays correct date for January & Monday', () => {
-
+        mockCurrentDate('2018-01-01T04:41:20');
         headerComponent.setState({ day: 1, month: "January", year: 2018, weekDay: "Monday" });
         expect(headerComponent.find('p').html()).toContain('Monday, 1 January, 2018');
     })
 
     it('displays correct date for February & Wednesday', () => {
+        mockCurrentDate('2018-02-07T04:45:20');
         headerComponent.setState({ day: 7, month: "February", year: 2018, weekDay: "Wednesday" });
         expect(headerComponent.find('p').html()).toContain('Wednesday, 7 February, 2018');
     })
 
     it('displays correct date for March & Thursday', () => {
+        mockCurrentDate('2018-03-01T01:41:20');
         headerComponent.setState({ day: 1, month: "March", year: 2018, weekDay: "Thursday" });
         expect(headerComponent.find('p').html()).toContain('Thursday, 1 March, 2018');
     })
 
     it('displays correct date for April & Friday', () => {
+        mockCurrentDate('2018-04-06T01:41:20');
         headerComponent.setState({ day: 6, month: "April", year: 2018, weekDay: "Friday" });
         expect(headerComponent.find('p').html()).toContain('Friday, 6 April, 2018');
     })
 
     it('displays correct date for May & Saturday', () => {
+        mockCurrentDate('2018-05-05T01:41:20');
         headerComponent.setState({ day: 5, month: "May", year: 2018, weekDay: "Saturday" });
         expect(headerComponent.find('p').html()).toContain('Saturday, 5 May, 2018');
     })
 
     it('displays correct date for June & Sunday', () => {
+        mockCurrentDate('2018-06-03T01:41:20');
         headerComponent.setState({ day: 3, month: "June", year: 2018, weekDay: "Sunday" });
         expect(headerComponent.find('p').html()).toContain('Sunday, 3 June, 2018');
     })
 
     it('displays correct date for July', () => {
+        mockCurrentDate('2018-07-01T01:41:20');
         headerComponent.setState({ day: 1, month: "July", year: 2018, weekDay: "Sunday" });
         expect(headerComponent.find('p').html()).toContain('Sunday, 1 July, 2018');
     })
 
     it('displays correct date for August', () => {
+        mockCurrentDate('2018-08-05T01:41:20');
         headerComponent.setState({ day: 5, month: "August", year: 2018, weekDay: "Sunday" });
         expect(headerComponent.find('p').html()).toContain('Sunday, 5 August, 2018');
     })
 
     it('displays correct date for September', () => {
+        mockCurrentDate('2018-09-02T01:41:20');
         headerComponent.setState({ day: 2, month: "September", year: 2018, weekDay: "Sunday" });
         expect(headerComponent.find('p').html()).toContain('Sunday, 2 September, 2018');
     })

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,28 +11,27 @@ class Header extends React.Component<{}, IHeaderState> {
 	constructor(props) {
 		super(props);
         this.setDate = this.setDate.bind(this);
-        this.setMonthFn = this.setMonthFn.bind(this);
+        this.setMonth = this.setMonth.bind(this);
         this.setDay = this.setDay.bind(this);
 		this.state = {day: 0, month: "", year: 0, weekDay:""};
 	}
 
 	componentDidMount() {
 
-	this.setDate();
+	    this.setDate();
 
 	}
 
 	setDate(): void {
 
-	const currentDate = new Date();
-	this.setState({day: currentDate.getDate()});
-	this.setState({year: currentDate.getFullYear()});
-    this.setMonthFn(currentDate);
-    this.setDay(currentDate);
-
+	    const currentDate = new Date();
+	    this.setState({day: currentDate.getDate()});
+	    this.setState({year: currentDate.getFullYear()});
+        this.setMonth(currentDate);
+        this.setDay(currentDate);
     }
     
-    setMonthFn = (currentDate): void => {
+    setMonth(currentDate): void {
         const month = currentDate.getMonth();
         let monthString: string;
         


### PR DESCRIPTION
Made sure that the tests are now actually using the functions inside the component as well and not just checking what's being displayed on the HTML. I had quite some trouble with resetting the Date right before every test and finally relented and used a 3rd party library to quickly solve it. Test coverage has increased quite a lot due to successful checking of the code.